### PR TITLE
マージ時にもpushトリガーは機能していたので設定を戻す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test CI
 
 on:
   push:
-  pull_request:
-    types:
-      - closed
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Issue
#6 

## 原因
わかった。。。
pushトリガーの問題じゃなくて、マージコミット内に `skip ci` が書いてあったせいでTest CIが動かなかったんだ。。。
なんという凡ミス。

![commit](https://user-images.githubusercontent.com/7730843/142736262-05a30c70-f200-4195-ac0e-1eb8c908bcb7.PNG)

ということは元のままで間違いなかったのね。まあ原因はっきりしてすっきりしたのでよしとしよう。今度から squash merge 時に skip ci の文言がコミットメッセージに入ってないか確認する。